### PR TITLE
Add precompile directive

### DIFF
--- a/src/Showoff.jl
+++ b/src/Showoff.jl
@@ -1,3 +1,5 @@
+VERSION >= v"0.4.0-dev+6641" && __precompile__()
+
 module Showoff
 
 using Compat


### PR DESCRIPTION
Passed `Pkg.test` on 0.4. Needed to resolve dependencies during precompilation.